### PR TITLE
Adapt hs-toxcore-c to new conferences state change callback.

### DIFF
--- a/src/Network/Tox/C/Tox.hs
+++ b/src/Network/Tox/C/Tox.hs
@@ -1828,11 +1828,8 @@ foreign import ccall tox_callback_conference_title :: Tox a -> FunPtr (CConferen
 
 -- | Peer list state change types.
 data ConferenceStateChange
-  = ConferenceStateChangePeerJoin
-    -- A peer has joined the conference.
-
-  | ConferenceStateChangePeerExit
-    -- A peer has exited the conference.
+  = ConferenceStateChangeListChanged
+    -- A peer has joined or exited the conference.
 
   | ConferenceStateChangePeerNameChange
     -- A peer has changed their name.


### PR DESCRIPTION
See https://github.com/TokTok/c-toxcore/pull/295.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-toxcore-c/17)
<!-- Reviewable:end -->
