### PR TITLE
Don't link against -ltoxcore explicitly.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -21,7 +21,6 @@ haskell_library(
 haskell_binary(
     name = "groupbot",
     srcs = ["tools/groupbot/Main.hs"],
-    compiler_flags = ["-ltoxcore"],
     prebuilt_dependencies = [
         "base",
         "bytestring",
@@ -37,7 +36,6 @@ haskell_binary(
 haskell_test(
     name = "test",
     srcs = glob(["test/**/*.hs"]),
-    compiler_flags = ["-ltoxcore"],
     main_file = "test/testsuite.hs",
     prebuilt_dependencies = [
         "base",


### PR DESCRIPTION
This no longer works once we start using `ghc_bindist`. For this to
actually work, we'll need https://github.com/tweag/rules_haskell/issues/170 to be fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-toxcore-c/23)
<!-- Reviewable:end -->
