### PR TITLE
Add GHC warning flags to bazel build.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,6 +6,11 @@ project("hs-toxcore-c")
 haskell_library(
     name = "hs-toxcore-c",
     srcs = glob(["src/**/*.*hs"]),
+    compiler_flags = [
+        "-Wall",
+        "-Werror",
+        "-Wno-unused-imports",
+    ],
     prebuilt_dependencies = [
         "base",
         "bytestring",
@@ -21,6 +26,11 @@ haskell_library(
 haskell_binary(
     name = "groupbot",
     srcs = ["tools/groupbot/Main.hs"],
+    compiler_flags = [
+        "-Wall",
+        "-Werror",
+        "-Wno-unused-imports",
+    ],
     prebuilt_dependencies = [
         "base",
         "bytestring",
@@ -36,6 +46,11 @@ haskell_binary(
 haskell_test(
     name = "test",
     srcs = glob(["test/**/*.hs"]),
+    compiler_flags = [
+        "-Wall",
+        "-Werror",
+        "-Wno-unused-imports",
+    ],
     main_file = "test/testsuite.hs",
     prebuilt_dependencies = [
         "base",

--- a/test/Network/Tox/C/ToxSpec.hs
+++ b/test/Network/Tox/C/ToxSpec.hs
@@ -5,10 +5,8 @@ module Network.Tox.C.ToxSpec where
 import           Control.Applicative               ((<$>), (<*>))
 import qualified Crypto.Saltine.Internal.ByteSizes as Sodium (boxPK, boxSK)
 import qualified Data.ByteString                   as BS
-import           Data.ByteString.Arbitrary         (ArbByteString (ABS),
-                                                    fromABS)
+import           Data.ByteString.Arbitrary         (fromABS)
 import           Data.Default.Class                (def)
-import           Data.Proxy                        (Proxy (..))
 import           Test.Hspec
 import           Test.QuickCheck
 import           Test.QuickCheck.Arbitrary         (arbitraryBoundedEnum,

--- a/test/Network/Tox/CSpec.hs
+++ b/test/Network/Tox/CSpec.hs
@@ -5,18 +5,14 @@ module Network.Tox.CSpec where
 
 import           Control.Applicative     ((<$>))
 import           Control.Concurrent      (threadDelay)
-import           Control.Concurrent.MVar (MVar, newMVar, putMVar, readMVar,
-                                          takeMVar)
+import           Control.Concurrent.MVar (MVar, newMVar, readMVar)
 import           Control.Exception       (bracket)
-import           Control.Monad           (replicateM_, when)
+import           Control.Monad           (when)
 import qualified Data.ByteString         as BS
 import qualified Data.ByteString.Base16  as Base16
 import           Data.String             (fromString)
-import           Foreign.Marshal.Alloc   (alloca)
-import           Foreign.Marshal.Utils   (with)
-import           Foreign.Ptr             (freeHaskellFunPtr, nullPtr)
-import           Foreign.StablePtr       (StablePtr, deRefStablePtr,
-                                          freeStablePtr, newStablePtr)
+import           Foreign.StablePtr       (StablePtr, freeStablePtr,
+                                          newStablePtr)
 import           Foreign.Storable        (Storable (..))
 import           Test.Hspec
 

--- a/tools/groupbot/Main.hs
+++ b/tools/groupbot/Main.hs
@@ -2,23 +2,15 @@
 {-# LANGUAGE LambdaCase                 #-}
 module Main (main) where
 
-import           Control.Applicative     ((<$>))
 import           Control.Concurrent      (threadDelay)
-import           Control.Concurrent.MVar (MVar, modifyMVar_, newMVar, putMVar,
-                                          readMVar, takeMVar)
+import           Control.Concurrent.MVar (MVar, newMVar)
 import           Control.Exception       (AsyncException (UserInterrupt), catch,
                                           throwIO)
-import           Control.Exception       (bracket)
-import           Control.Monad           (forever, replicateM_, when)
+import           Control.Monad           (forever)
 import qualified Data.ByteString.Base16  as Base16
 import qualified Data.ByteString.Char8   as BS
 import           Data.String             (fromString)
 import           Data.Word               (Word32)
-import           Foreign.Marshal.Alloc   (alloca)
-import           Foreign.Marshal.Utils   (with)
-import           Foreign.Ptr             (freeHaskellFunPtr, nullPtr)
-import           Foreign.StablePtr       (StablePtr, deRefStablePtr,
-                                          freeStablePtr, newStablePtr)
 import           Foreign.Storable        (Storable (..))
 import           System.Directory        (doesFileExist)
 import           System.Exit             (exitSuccess)


### PR DESCRIPTION
`-Werror` is fine here because we control the exact version of GHC we are
building with (currently 8.2.2), so there is no risk of getting different
warnings on different installations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-toxcore-c/24)
<!-- Reviewable:end -->
