### PR TITLE
chore: Fix compilation with newer GHC

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.18
+    image: toxchat/toktok-stack:0.0.19
     cpu: 2
     memory: 6G
   configure_script:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 ---
 packages: [.]
-resolver: lts-14.27
+resolver: lts-16.12
 extra-deps:
   - bytestring-arbitrary-0.1.3@sha256:14db64d4fe126fbad2eb8d3601bfd80a693f3131e2db0e76891feffe44f10df8,1773


### PR DESCRIPTION
A constraint was missing so it can compile with newer GHC from lts-16

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-toxcore-c/43)
<!-- Reviewable:end -->
