### PR TITLE
perf: Use StrictData for all modules that define data types.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,9 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.15
+    image: toxchat/toktok-stack:0.0.18
     cpu: 2
-    memory: 4G
+    memory: 6G
   configure_script:
     - /src/workspace/tools/inject-repo hs-toxcore-c
   test_all_script:

--- a/src/Network/Tox/C/CEnum.hs
+++ b/src/Network/Tox/C/CEnum.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StrictData                 #-}
 {-# LANGUAGE Trustworthy                #-}
 module Network.Tox.C.CEnum where
 

--- a/src/Network/Tox/C/Callbacks.hs
+++ b/src/Network/Tox/C/Callbacks.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE StrictData #-}
 module Network.Tox.C.Callbacks where
 
 import           Control.Exception  (bracket)

--- a/src/Network/Tox/C/Constants.hs
+++ b/src/Network/Tox/C/Constants.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE StrictData  #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.C.Constants where
 

--- a/src/Network/Tox/C/Options.hs
+++ b/src/Network/Tox/C/Options.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase    #-}
 {-# LANGUAGE Safe          #-}
+{-# LANGUAGE StrictData    #-}
 module Network.Tox.C.Options where
 
 import           Control.Applicative ((<$>))

--- a/src/Network/Tox/C/Tox.hs
+++ b/src/Network/Tox/C/Tox.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE Safe       #-}
+{-# LANGUAGE StrictData #-}
 -- | Public core API for Tox clients.
 --
 -- Every function that can fail takes a function-specific error code pointer

--- a/src/Network/Tox/C/Type.hs
+++ b/src/Network/Tox/C/Type.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE Safe #-}
+{-# LANGUAGE Safe       #-}
+{-# LANGUAGE StrictData #-}
 module Network.Tox.C.Type where
 
 import           Control.Concurrent.MVar (MVar)

--- a/src/Network/Tox/C/Version.hs
+++ b/src/Network/Tox/C/Version.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE StrictData  #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.C.Version where
 

--- a/test/Data/ByteString/Arbitrary.hs
+++ b/test/Data/ByteString/Arbitrary.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE StrictData #-}
 module Data.ByteString.Arbitrary
 ( ArbByteString(..)
 , ArbByteString1M(..)

--- a/test/Network/Tox/C/ToxSpec.hs
+++ b/test/Network/Tox/C/ToxSpec.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE StrictData  #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.C.ToxSpec where
 

--- a/test/Network/Tox/CSpec.hs
+++ b/test/Network/Tox/CSpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StrictData                 #-}
 {-# LANGUAGE Trustworthy                #-}
 module Network.Tox.CSpec where
 

--- a/tools/groupbot.hs
+++ b/tools/groupbot.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE StrictData                 #-}
 module Main (main) where
 
 import           Control.Concurrent      (threadDelay)


### PR DESCRIPTION
I've added StrictData to some modules that don't currently define data
types, mostly by mistake, but it doesn't harm and avoids missing it in
the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-toxcore-c/47)
<!-- Reviewable:end -->
