### PR TITLE
chore: Restrict generic-arbitrary version.

### DIFF
--- a/toxcore-c.cabal
+++ b/toxcore-c.cabal
@@ -40,7 +40,7 @@ library
     , QuickCheck
     , bytestring
     , data-default-class
-    , generic-arbitrary
+    , generic-arbitrary         < 0.2
     , msgpack-binary
     , quickcheck-instances
 


### PR DESCRIPTION
0.2.0 broke Safe haskell.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-toxcore-c/59)
<!-- Reviewable:end -->
