### PR TITLE
cleanup: Remove polymorphism in Tox.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,7 +8,6 @@ project()
 haskell_library(
     name = "hs-toxcore-c",
     srcs = glob(["src/**/*.*hs"]),
-    compiler_flags = ["-Wno-unused-imports"],
     src_strip_prefix = "src",
     version = "0.2.12",
     visibility = ["//visibility:public"],
@@ -18,7 +17,6 @@ haskell_library(
         hazel_library("QuickCheck"),
         hazel_library("base"),
         hazel_library("bytestring"),
-        hazel_library("data-default-class"),
         hazel_library("generic-arbitrary"),
         hazel_library("quickcheck-instances"),
     ],
@@ -27,7 +25,6 @@ haskell_library(
 hspec_test(
     name = "testsuite",
     timeout = "short",
-    compiler_flags = ["-Wno-unused-imports"],
     deps = [
         ":hs-toxcore-c",
         "//hs-msgpack-binary",
@@ -36,7 +33,6 @@ hspec_test(
         hazel_library("base16-bytestring"),
         hazel_library("bytestring"),
         hazel_library("cryptohash"),
-        hazel_library("data-default-class"),
         hazel_library("hspec"),
         hazel_library("saltine"),
         hazel_library("vector"),

--- a/src/Network/Tox/C/CEnum.hs
+++ b/src/Network/Tox/C/CEnum.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE Trustworthy                #-}
 module Network.Tox.C.CEnum where
 
-import           Control.Applicative   ((<$>))
 import           Foreign.C.Types       (CInt)
 import           Foreign.Marshal.Alloc (alloca)
 import           Foreign.Ptr           (Ptr)
@@ -32,7 +31,7 @@ callErrFun :: (Eq err, Enum err, Bounded err)
            => (CErr err -> IO r) -> IO (Either err r)
 callErrFun f = alloca $ \errPtr -> do
   res <- f errPtr
-  err <- toEnum . fromIntegral . unCEnum <$> peek errPtr
-  return $ if err /= minBound
-    then Left  err
+  err <- unCEnum <$> peek errPtr
+  return $ if err > 0
+    then Left . toEnum . fromIntegral $ err - 1
     else Right res

--- a/src/Network/Tox/C/Constants.hs
+++ b/src/Network/Tox/C/Constants.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE StrictData  #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.C.Constants where

--- a/src/Network/Tox/C/Options.hs
+++ b/src/Network/Tox/C/Options.hs
@@ -4,15 +4,13 @@
 {-# LANGUAGE StrictData    #-}
 module Network.Tox.C.Options where
 
-import           Control.Applicative ((<$>))
 import           Control.Exception   (bracket)
 import           Data.ByteString     (ByteString)
 import qualified Data.ByteString     as BS
-import           Data.Default.Class  (Default (..))
-import           Data.Word           (Word16)
+import           Data.Word           (Word16, Word32)
 import           Foreign.C.String    (CString, peekCString, withCString)
 import           Foreign.C.Types     (CInt (..), CSize (..))
-import           Foreign.Ptr         (Ptr, nullPtr)
+import           Foreign.Ptr         (FunPtr, Ptr, nullPtr)
 import           GHC.Generics        (Generic)
 
 import           Network.Tox.C.CEnum
@@ -26,102 +24,102 @@ import           Network.Tox.C.CEnum
 
 -- | Type of proxy used to connect to TCP relays.
 data ProxyType
-  = ProxyTypeNone
-    -- Don't use a proxy.
-  | ProxyTypeHttp
-    -- HTTP proxy using CONNECT.
-  | ProxyTypeSocks5
-    -- SOCKS proxy for simple socket pipes.
-  deriving (Eq, Ord, Enum, Bounded, Read, Show, Generic)
+    = ProxyTypeNone
+      -- Don't use a proxy.
+    | ProxyTypeHttp
+      -- HTTP proxy using CONNECT.
+    | ProxyTypeSocks5
+      -- SOCKS proxy for simple socket pipes.
+    deriving (Eq, Ord, Enum, Bounded, Read, Show, Generic)
 
 
 -- Type of savedata to create the Tox instance from.
 data SavedataType
-  = SavedataTypeNone
-    -- No savedata.
-  | SavedataTypeToxSave
-    -- Savedata is one that was obtained from tox_get_savedata
-  | SavedataTypeSecretKey
-    -- Savedata is a secret key of length 'tox_secret_key_size'
-  deriving (Eq, Ord, Enum, Bounded, Read, Show, Generic)
+    = SavedataTypeNone
+      -- No savedata.
+    | SavedataTypeToxSave
+      -- Savedata is one that was obtained from tox_get_savedata
+    | SavedataTypeSecretKey
+      -- Savedata is a secret key of length 'tox_secret_key_size'
+    deriving (Eq, Ord, Enum, Bounded, Read, Show, Generic)
 
 
 -- This struct contains all the startup options for Tox. You can either allocate
 -- this object yourself, and pass it to tox_options_default, or call
 -- tox_options_new to get a new default options object.
 data Options = Options
-  { ipv6Enabled  :: Bool
-    -- The type of socket to create.
-    --
-    -- If this is set to false, an IPv4 socket is created, which subsequently
-    -- only allows IPv4 communication.
-    -- If it is set to true, an IPv6 socket is created, allowing both IPv4 and
-    -- IPv6 communication.
+    { ipv6Enabled  :: Bool
+      -- The type of socket to create.
+      --
+      -- If this is set to false, an IPv4 socket is created, which subsequently
+      -- only allows IPv4 communication.
+      -- If it is set to true, an IPv6 socket is created, allowing both IPv4 and
+      -- IPv6 communication.
 
-  , udpEnabled   :: Bool
-    -- Enable the use of UDP communication when available.
-    --
-    -- Setting this to false will force Tox to use TCP only. Communications will
-    -- need to be relayed through a TCP relay node, potentially slowing them
-    -- down. Disabling UDP support is necessary when using anonymous proxies or
-    -- Tor.
+    , udpEnabled   :: Bool
+      -- Enable the use of UDP communication when available.
+      --
+      -- Setting this to false will force Tox to use TCP only. Communications will
+      -- need to be relayed through a TCP relay node, potentially slowing them
+      -- down. Disabling UDP support is necessary when using anonymous proxies or
+      -- Tor.
 
-  , proxyType    :: ProxyType
-    -- Pass communications through a proxy.
+    , proxyType    :: ProxyType
+      -- Pass communications through a proxy.
 
-  , proxyHost    :: String
-    -- The IP address or DNS name of the proxy to be used.
-    --
-    -- If used, this must be non-'nullPtr' and be a valid DNS name. The name
-    -- must not exceed 255 ('tox_max_filename_length') characters, and be in a
-    -- NUL-terminated C string format (255 chars + 1 NUL byte).
-    --
-    -- This member is ignored (it can be 'nullPtr') if proxy_type is
-    -- ProxyTypeNone.
+    , proxyHost    :: String
+      -- The IP address or DNS name of the proxy to be used.
+      --
+      -- If used, this must be non-'nullPtr' and be a valid DNS name. The name
+      -- must not exceed 255 ('tox_max_filename_length') characters, and be in a
+      -- NUL-terminated C string format (255 chars + 1 NUL byte).
+      --
+      -- This member is ignored (it can be 'nullPtr') if proxy_type is
+      -- ProxyTypeNone.
 
-  , proxyPort    :: Word16
-    -- The port to use to connect to the proxy server.
-    --
-    -- Ports must be in the range (1, 65535). The value is ignored if proxy_type
-    -- is ProxyTypeNone.
+    , proxyPort    :: Word16
+      -- The port to use to connect to the proxy server.
+      --
+      -- Ports must be in the range (1, 65535). The value is ignored if proxy_type
+      -- is ProxyTypeNone.
 
-  , startPort    :: Word16
-    -- The start port of the inclusive port range to attempt to use.
-    --
-    -- If both 'startPort' and 'endPort' are 0, the default port range will be
-    -- used: [33445, 33545].
-    --
-    -- If either 'startPort' or 'endPort' is 0 while the other is non-zero, the
-    -- non-zero port will be the only port in the range.
-    --
-    -- Having 'startPort' > 'endport' will yield the same behavior as if
-    -- 'startPort' and 'endPort' were swapped.
+    , startPort    :: Word16
+      -- The start port of the inclusive port range to attempt to use.
+      --
+      -- If both 'startPort' and 'endPort' are 0, the default port range will be
+      -- used: [33445, 33545].
+      --
+      -- If either 'startPort' or 'endPort' is 0 while the other is non-zero, the
+      -- non-zero port will be the only port in the range.
+      --
+      -- Having 'startPort' > 'endport' will yield the same behavior as if
+      -- 'startPort' and 'endPort' were swapped.
 
-  , endPort      :: Word16
-    -- The end port of the inclusive port range to attempt to use.
+    , endPort      :: Word16
+      -- The end port of the inclusive port range to attempt to use.
 
-  , tcpPort      :: Word16
-    -- The port to use for the TCP server (relay). If 0, the TCP server is
-    -- disabled.
-    --
-    -- Enabling it is not required for Tox to function properly.
-    --
-    -- When enabled, your Tox instance can act as a TCP relay for other Tox
-    -- instance. This leads to increased traffic, thus when writing a client it
-    -- is recommended to enable TCP server only if the user has an option to
-    -- disable it.
+    , tcpPort      :: Word16
+      -- The port to use for the TCP server (relay). If 0, the TCP server is
+      -- disabled.
+      --
+      -- Enabling it is not required for Tox to function properly.
+      --
+      -- When enabled, your Tox instance can act as a TCP relay for other Tox
+      -- instance. This leads to increased traffic, thus when writing a client it
+      -- is recommended to enable TCP server only if the user has an option to
+      -- disable it.
 
-  , savedataType :: SavedataType
-    -- The type of savedata to load from.
+    , savedataType :: SavedataType
+      -- The type of savedata to load from.
 
-  , savedataData :: ByteString
-    -- The savedata bytes.
-  }
-  deriving (Eq, Read, Show, Generic)
+    , savedataData :: ByteString
+      -- The savedata bytes.
+    }
+    deriving (Eq, Read, Show, Generic)
 
 
-instance Default Options where
-  def = Options
+defaultOptions :: Options
+defaultOptions = Options
     { ipv6Enabled  = True
     , udpEnabled   = True
     , proxyType    = ProxyTypeNone
@@ -164,14 +162,41 @@ foreign import ccall tox_options_set_savedata_data    :: OptionsPtr -> CString -
 foreign import ccall tox_options_set_savedata_length  :: OptionsPtr -> CSize -> IO ()
 
 
-data ErrOptionsNew
-  = ErrOptionsNewOk
-    -- The function returned successfully.
+data LogLevel
+    = LogLevelTrace
+    | LogLevelDebug
+    | LogLevelInfo
+    | LogLevelWarning
+    | LogLevelError
+    deriving (Eq, Ord, Enum, Bounded, Read, Show)
 
-  | ErrOptionsNewMalloc
-    -- The function was unable to allocate enough memory to store the internal
-    -- structures for the Tox options object.
-  deriving (Eq, Ord, Enum, Bounded, Read, Show)
+logLevelName :: LogLevel -> Char
+logLevelName LogLevelTrace   = 'T'
+logLevelName LogLevelDebug   = 'D'
+logLevelName LogLevelInfo    = 'I'
+logLevelName LogLevelWarning = 'W'
+logLevelName LogLevelError   = 'E'
+
+type LogCb = Ptr () -> CEnum LogLevel -> CString -> Word32 -> CString -> CString -> Ptr () -> IO ()
+foreign import ccall tox_options_set_log_callback :: OptionsPtr -> FunPtr LogCb -> IO ()
+foreign import ccall "wrapper" wrapLogCb :: LogCb -> IO (FunPtr LogCb)
+
+logHandler :: LogCb
+logHandler _ cLevel cFile line cFunc cMsg _ = do
+    let level = fromCEnum cLevel
+    file <- peekCString cFile
+    func <- peekCString cFunc
+    msg <- peekCString cMsg
+    case level of
+        LogLevelTrace -> return ()
+        _ -> putStrLn $ logLevelName level : ' ' : file <> ":" <> show line <> "(" <> func <> "): " <> msg
+
+
+data ErrOptionsNew
+    = ErrOptionsNewMalloc
+      -- The function was unable to allocate enough memory to store the internal
+      -- structures for the Tox options object.
+    deriving (Eq, Ord, Enum, Bounded, Read, Show)
 
 
 -- | Allocates a new Tox_Options object and initialises it with the default
@@ -192,14 +217,14 @@ toxOptionsNew = callErrFun tox_options_new
 --
 -- Passing a pointer that was not returned by tox_options_new results in
 -- undefined behaviour.
-foreign import ccall tox_options_free :: OptionsPtr -> IO ()
+foreign import ccall "tox_options_free" toxOptionsFree :: OptionsPtr -> IO ()
 
 
 withToxOptions :: (OptionsPtr -> IO r) -> IO (Either ErrOptionsNew r)
 withToxOptions f =
-  bracket toxOptionsNew (either (const $ return ()) tox_options_free) $ \case
-    Left err -> return $ Left err
-    Right ok -> Right <$> f ok
+    bracket toxOptionsNew (either (const $ return ()) toxOptionsFree) $ \case
+        Left err -> return $ Left err
+        Right ok -> Right <$> f ok
 
 
 -- | Read 'Options' from an 'OptionsPtr'.
@@ -207,103 +232,40 @@ withToxOptions f =
 -- If the passed pointer is 'nullPtr', the behaviour is undefined.
 peekToxOptions :: OptionsPtr -> IO Options
 peekToxOptions ptr = do
-  cIpv6Enabled    <- tox_options_get_ipv6_enabled    ptr
-  cUdpEnabled     <- tox_options_get_udp_enabled     ptr
-  cProxyType      <- tox_options_get_proxy_type      ptr
-  cProxyHost      <- tox_options_get_proxy_host      ptr >>= peekNullableString
-  cProxyPort      <- tox_options_get_proxy_port      ptr
-  cStartPort      <- tox_options_get_start_port      ptr
-  cEndPort        <- tox_options_get_end_port        ptr
-  cTcpPort        <- tox_options_get_tcp_port        ptr
-  cSavedataType   <- tox_options_get_savedata_type   ptr
-  cSavedataData   <- tox_options_get_savedata_data   ptr
-  cSavedataLength <- tox_options_get_savedata_length ptr
-  cSavedata       <- BS.packCStringLen
-                           ( cSavedataData
-                           , fromIntegral cSavedataLength)
-  return Options
-    { ipv6Enabled    = cIpv6Enabled
-    , udpEnabled     = cUdpEnabled
-    , proxyType      = fromCEnum cProxyType
-    , proxyHost      = cProxyHost
-    , proxyPort      = cProxyPort
-    , startPort      = cStartPort
-    , endPort        = cEndPort
-    , tcpPort        = cTcpPort
-    , savedataType   = fromCEnum cSavedataType
-    , savedataData   = cSavedata
-    }
+    cIpv6Enabled    <- tox_options_get_ipv6_enabled    ptr
+    cUdpEnabled     <- tox_options_get_udp_enabled     ptr
+    cProxyType      <- tox_options_get_proxy_type      ptr
+    cProxyHost      <- tox_options_get_proxy_host      ptr >>= peekNullableString
+    cProxyPort      <- tox_options_get_proxy_port      ptr
+    cStartPort      <- tox_options_get_start_port      ptr
+    cEndPort        <- tox_options_get_end_port        ptr
+    cTcpPort        <- tox_options_get_tcp_port        ptr
+    cSavedataType   <- tox_options_get_savedata_type   ptr
+    cSavedataData   <- tox_options_get_savedata_data   ptr
+    cSavedataLength <- tox_options_get_savedata_length ptr
+    cSavedata       <- BS.packCStringLen
+                             ( cSavedataData
+                             , fromIntegral cSavedataLength)
+    return Options
+        { ipv6Enabled    = cIpv6Enabled
+        , udpEnabled     = cUdpEnabled
+        , proxyType      = fromCEnum cProxyType
+        , proxyHost      = cProxyHost
+        , proxyPort      = cProxyPort
+        , startPort      = cStartPort
+        , endPort        = cEndPort
+        , tcpPort        = cTcpPort
+        , savedataType   = fromCEnum cSavedataType
+        , savedataData   = cSavedata
+        }
 
   where
     -- 'peekCString' doesn't handle NULL strings as empty, unlike
     -- 'packCStringLen', which ignores the pointer to zero-length 'CString's.
     peekNullableString p =
-      if p == nullPtr
-        then return ""
-        else peekCString p
-
-
--- | Save the options from the passed 'OptionsPtr', perform an IO action, and
--- restore the original values.
---
--- If the passed pointer is 'nullPtr', the behaviour is undefined.
-saveToxOptions :: OptionsPtr -> IO r -> IO r
-saveToxOptions ptr =
-  bracket saveOptions restoreOptions . const
-  where
-    saveOptions = do
-      v0 <- tox_options_get_ipv6_enabled    ptr
-      v1 <- tox_options_get_udp_enabled     ptr
-      v2 <- tox_options_get_proxy_type      ptr
-      v3 <- tox_options_get_proxy_host      ptr
-      v4 <- tox_options_get_proxy_port      ptr
-      v5 <- tox_options_get_start_port      ptr
-      v6 <- tox_options_get_end_port        ptr
-      v7 <- tox_options_get_tcp_port        ptr
-      v8 <- tox_options_get_savedata_type   ptr
-      sd <- tox_options_get_savedata_data   ptr
-      sl <- tox_options_get_savedata_length ptr
-      return (v0, v1, v2, v3, v4, v5, v6, v7, v8, sd, sl)
-
-    restoreOptions (v0, v1, v2, v3, v4, v5, v6, v7, v8, sd, sl) = do
-      tox_options_set_ipv6_enabled    ptr v0
-      tox_options_set_udp_enabled     ptr v1
-      tox_options_set_proxy_type      ptr v2
-      tox_options_set_proxy_host      ptr v3
-      tox_options_set_proxy_port      ptr v4
-      tox_options_set_start_port      ptr v5
-      tox_options_set_end_port        ptr v6
-      tox_options_set_tcp_port        ptr v7
-      tox_options_set_savedata_type   ptr v8
-      tox_options_set_savedata_data   ptr sd sl
-      tox_options_set_savedata_length ptr sl
-
-
--- | Fill in the 'Options' values into the 'OptionsPtr' and perform the IO
--- action afterwards.
---
--- This function restores the original values from the 'OptionsPtr' after
--- performing the action.
---
--- If the passed pointer is 'nullPtr', the behaviour is undefined.
-pokeToxOptions :: Options -> OptionsPtr -> IO r -> IO r
-pokeToxOptions options ptr action =
-  saveToxOptions ptr $
-    withCString (proxyHost options) $ \host ->
-      BS.useAsCStringLen (savedataData options) $ \(saveData, saveLenInt) -> do
-        let saveLen = fromIntegral saveLenInt
-        tox_options_set_ipv6_enabled    ptr $ ipv6Enabled options
-        tox_options_set_udp_enabled     ptr $ udpEnabled options
-        tox_options_set_proxy_type      ptr $ toCEnum $ proxyType options
-        tox_options_set_proxy_host      ptr host
-        tox_options_set_proxy_port      ptr $ proxyPort options
-        tox_options_set_start_port      ptr $ startPort options
-        tox_options_set_end_port        ptr $ endPort options
-        tox_options_set_tcp_port        ptr $ tcpPort options
-        tox_options_set_savedata_type   ptr $ toCEnum $ savedataType options
-        tox_options_set_savedata_data   ptr saveData saveLen
-        tox_options_set_savedata_length ptr saveLen
-        action
+        if p == nullPtr
+            then return ""
+            else peekCString p
 
 
 -- | Allocate a new C options pointer, fills in the values from 'Options',
@@ -314,5 +276,20 @@ pokeToxOptions options ptr action =
 -- error code.
 withOptions :: Options -> (OptionsPtr -> IO r) -> IO (Either ErrOptionsNew r)
 withOptions options f =
-  withToxOptions $ \ptr ->
-    pokeToxOptions options ptr (f ptr)
+    withToxOptions $ \ptr ->
+        withCString (proxyHost options) $ \host ->
+            BS.useAsCStringLen (savedataData options) $ \(saveData, saveLenInt) -> do
+                let saveLen = fromIntegral saveLenInt
+                tox_options_set_ipv6_enabled    ptr $ ipv6Enabled options
+                tox_options_set_udp_enabled     ptr $ udpEnabled options
+                tox_options_set_proxy_type      ptr $ toCEnum $ proxyType options
+                tox_options_set_proxy_host      ptr host
+                tox_options_set_proxy_port      ptr $ proxyPort options
+                tox_options_set_start_port      ptr $ startPort options
+                tox_options_set_end_port        ptr $ endPort options
+                tox_options_set_tcp_port        ptr $ tcpPort options
+                tox_options_set_savedata_type   ptr $ toCEnum $ savedataType options
+                tox_options_set_savedata_data   ptr saveData saveLen
+                tox_options_set_savedata_length ptr saveLen
+                tox_options_set_log_callback    ptr =<< wrapLogCb logHandler
+                f ptr

--- a/src/Network/Tox/C/Type.hs
+++ b/src/Network/Tox/C/Type.hs
@@ -3,10 +3,8 @@
 {-# LANGUAGE StrictData    #-}
 module Network.Tox.C.Type where
 
-import           Control.Concurrent.MVar   (MVar)
 import           Data.MessagePack          (MessagePack)
 import           Foreign.Ptr               (Ptr)
-import           Foreign.StablePtr         (StablePtr)
 import           GHC.Generics              (Generic)
 import           Test.QuickCheck.Arbitrary (Arbitrary (..),
                                             arbitraryBoundedEnum)
@@ -17,13 +15,8 @@ import           Test.QuickCheck.Arbitrary (Arbitrary (..),
 -- The maximum number of Tox instances that can exist on a single network device
 -- is limited. Note that this is not just a per-process limit, since the
 -- limiting factor is the number of usable ports on a device.
-data ToxStruct a
-type Tox a = Ptr (ToxStruct a)
-
-data ToxEventsStruct
-type ToxEvents = Ptr ToxEventsStruct
-
-type UserData a = StablePtr (MVar a)
+data ToxStruct
+type Tox = Ptr ToxStruct
 
 
 -- | Protocols that can be used to connect to the network or friends.

--- a/test/Network/Tox/C/EventsSpec.hs
+++ b/test/Network/Tox/C/EventsSpec.hs
@@ -1,54 +1,19 @@
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE StrictData                 #-}
-{-# LANGUAGE Trustworthy                #-}
-{-# LANGUAGE ViewPatterns               #-}
+{-# LANGUAGE StrictData   #-}
+{-# LANGUAGE Trustworthy  #-}
+{-# LANGUAGE ViewPatterns #-}
 module Network.Tox.C.EventsSpec where
 
-import           Control.Applicative     ((<$>))
-import           Control.Concurrent      (threadDelay)
-import           Control.Concurrent.MVar (MVar, newMVar, readMVar)
-import           Control.Exception       (bracket)
-import           Control.Monad           (when)
-import qualified Data.ByteString         as BS
-import qualified Data.ByteString.Base16  as Base16
-import           Data.List               (sort)
-import           Data.MessagePack        (Object (..))
-import qualified Data.MessagePack        as MP
-import           Data.String             (fromString)
-import qualified Data.Vector             as V
-import           Foreign.StablePtr       (StablePtr, freeStablePtr,
-                                          newStablePtr)
-import           Foreign.Storable        (Storable (..))
+import           Control.Concurrent   (threadDelay)
+import           Control.Monad        (forM)
+import           Data.List            (sort)
+import           Data.MessagePack     (Object (..))
+import qualified Data.MessagePack     as MP
+import qualified Data.Vector          as V
 import           Test.Hspec
 import           Test.QuickCheck
 
-import qualified Network.Tox.C           as C
+import qualified Network.Tox.C        as C
 import           Network.Tox.C.Events
-
-
-bootstrapKey :: BS.ByteString
-Right bootstrapKey =
-  Base16.decode . fromString $
-    "8E7D0B859922EF569298B4D261A8CCB5FEA14FB91ED412A7603A585A25698832"
-
-bootstrapHost :: String
-bootstrapHost = "95.79.50.56"
-
-
-options :: C.Options
-options = C.Options
-  { C.ipv6Enabled  = True
-  , C.udpEnabled   = True
-  , C.proxyType    = C.ProxyTypeNone
-  , C.proxyHost    = ""
-  , C.proxyPort    = 0
-  , C.startPort    = 33445
-  , C.endPort      = 33545
-  , C.tcpPort      = 3128
-  , C.savedataType = C.SavedataTypeNone
-  , C.savedataData = BS.empty
-  }
 
 
 getRight :: (MonadFail m, Show a) => Either a b -> m b
@@ -65,42 +30,42 @@ processEvent SelfConnectionStatus{} = return True
 processEvent _                      = return False
 
 
-toxIterate :: C.Tox a -> IO ()
-toxIterate tox = do
-    putStrLn "tox_iterate"
-    interval <- C.toxIterationInterval tox
+toxIterate :: Int -> [C.Tox] -> IO ()
+toxIterate 0 _ = expectationFailure "could not bootstrap"
+toxIterate countdown toxes = do
+    interval <- foldr max 0 <$> mapM C.toxIterationInterval toxes
     threadDelay $ fromIntegral $ interval * 10000
 
-    events <- must $ C.toxEventsIterate tox
-    result <- mapM processEvent events
+    connected <- fmap and . forM toxes $ \tox -> do
+        events <- must $ C.toxEventsIterate tox
+        or <$> mapM processEvent events
 
-    if or result
+    if connected
        then putStrLn "connected"
-       else toxIterate tox
+       else toxIterate (countdown - 1) toxes
 
 
 spec :: Spec
 spec = do
-    describe "serialisation format" $ do
-        it "is linear encoding" $ do
+    describe "event serialisation format" $ do
+        it "is linear encoding" $
             MP.toObject MP.defaultConfig (FileChunkRequest 1 2 3 4)
                 `shouldBe` ObjectArray (V.fromList
                     [ ObjectWord 11
                     , ObjectArray (V.fromList
                         [ObjectWord 1,ObjectWord 2,ObjectWord 3,ObjectWord 4])])
 
-        it "can round-trip through toxcore" $ do
+        it "can round-trip through toxcore" $
             property $ \(sort -> events) -> do
                 events' <- C.toxEventsToPtr events >>= C.toxEventsFromPtr
                 sort <$> events' `shouldBe` Right events
 
-    describe "toxcore" $ do
+    describe "toxcore" $
         it "can bootstrap" $ do
-            putStrLn "bootstrap"
-            must $ C.withOptions options $ \optPtr ->
-                must $ C.withTox optPtr $ \tox -> do
-                    C.tox_events_init tox
-                    must $ C.toxBootstrap   tox bootstrapHost 33445 bootstrapKey
-                    must $ C.toxAddTcpRelay tox bootstrapHost 33445 bootstrapKey
+            must $ C.withTox C.defaultOptions $ \tox1 ->
+                must $ C.withTox C.defaultOptions $ \tox2 -> do
+                    bootstrapPort <- must $ C.toxSelfGetUdpPort tox1
+                    bootstrapKey <- C.toxSelfGetDhtId tox1
+                    must $ C.toxBootstrap tox2 "localhost" bootstrapPort bootstrapKey
 
-                    toxIterate tox
+                    toxIterate 100 [tox1, tox2]

--- a/test/Network/Tox/C/ToxSpec.hs
+++ b/test/Network/Tox/C/ToxSpec.hs
@@ -3,25 +3,23 @@
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.C.ToxSpec where
 
-import           Control.Applicative               ((<$>), (<*>))
 import qualified Crypto.Saltine.Internal.ByteSizes as Sodium (boxPK, boxSK)
 import qualified Data.ByteString                   as BS
-import           Data.Default.Class                (def)
 import           Test.Hspec
 import           Test.QuickCheck
-import           Test.QuickCheck.Arbitrary         (arbitraryBoundedEnum,
-                                                    genericShrink)
 
 import qualified Network.Tox.C                     as C
 
+{-# ANN module "HLint: ignore Reduce duplication" #-}
+{-# ANN module "HLint: ignore Redundant do" #-}
 
 instance Arbitrary C.ProxyType where
-  shrink = genericShrink
-  arbitrary = arbitraryBoundedEnum
+    shrink = genericShrink
+    arbitrary = arbitraryBoundedEnum
 
 instance Arbitrary C.SavedataType where
-  shrink = genericShrink
-  arbitrary = arbitraryBoundedEnum
+    shrink = genericShrink
+    arbitrary = arbitraryBoundedEnum
 
 -- | Ensure that the hostname has a chance of being valid.
 filterHost :: C.Options -> C.Options
@@ -30,18 +28,18 @@ filterHost o@C.Options{C.proxyHost = h} = o{C.proxyHost = filter (`elem` hostCha
     hostChars = ".-_" ++ ['0'..'9'] ++ ['a'..'z'] ++ ['A'..'Z']
 
 instance Arbitrary C.Options where
-  shrink = map filterHost . genericShrink
-  arbitrary = fmap filterHost $ C.Options
-    <$> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
+    shrink = map filterHost . genericShrink
+    arbitrary = fmap filterHost $ C.Options
+        <$> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
 
 
 getRight :: (MonadFail m, Show a) => Either a b -> m b
@@ -55,61 +53,60 @@ must = (getRight =<<)
 
 spec :: Spec
 spec = do
-  describe "tox_version_is_compatible" $
-    it "is compatible with the major/minor/patch of the linked library" $
-      C.tox_version_is_compatible
-        C.tox_version_major
-        C.tox_version_minor
-        C.tox_version_patch
-      `shouldBe` True
+    describe "tox_version_is_compatible" $ do
+        it "is compatible with the major/minor/patch of the linked library" $ do
+            C.tox_version_is_compatible
+                C.tox_version_major
+                C.tox_version_minor
+                C.tox_version_patch
+                `shouldBe` True
 
-  describe "Constants" $
-    it "has constants equal to the hstox expected key size" $ do
-      fromIntegral C.tox_public_key_size `shouldBe` Sodium.boxPK
-      fromIntegral C.tox_secret_key_size `shouldBe` Sodium.boxSK
-      C.tox_address_size `shouldBe` C.tox_public_key_size + 6
-      C.tox_max_name_length `shouldBe` 128
-      C.tox_max_status_message_length `shouldBe` 1007
-      C.tox_max_friend_request_length `shouldBe` 1016
-      C.tox_max_message_length `shouldBe` C.tox_max_custom_packet_size - 1
-      C.tox_max_custom_packet_size `shouldBe` 1373
-      C.tox_max_filename_length `shouldBe` 255
-      C.tox_hash_length `shouldBe` C.tox_file_id_length
+    describe "Constants" $ do
+        it "has constants equal to the hstox expected key size" $ do
+            fromIntegral C.tox_public_key_size `shouldBe` Sodium.boxPK
+            fromIntegral C.tox_secret_key_size `shouldBe` Sodium.boxSK
+            C.tox_address_size `shouldBe` C.tox_public_key_size + 6
+            C.tox_max_name_length `shouldBe` 128
+            C.tox_max_status_message_length `shouldBe` 1007
+            C.tox_max_friend_request_length `shouldBe` 1016
+            C.tox_max_message_length `shouldBe` C.tox_max_custom_packet_size - 1
+            C.tox_max_custom_packet_size `shouldBe` 1373
+            C.tox_max_filename_length `shouldBe` 255
+            C.tox_hash_length `shouldBe` C.tox_file_id_length
 
-  describe "Options" $ do
-    it "can be marshalled to C and back" $
-      property $ \options -> do
-        res <- C.withOptions options C.peekToxOptions
-        res `shouldBe` Right options
+    describe "Options" $ do
+        it "can be marshalled to C and back" $ do
+            property $ \options -> do
+                res <- C.withOptions options C.peekToxOptions
+                res `shouldBe` Right options
 
-    it "is saved correctly by pokeToxOptions" $
-      property $ \options0 options1 -> do
-        res <- C.withOptions options0 $ \ptr -> do
-          C.pokeToxOptions options1 ptr (return ())
-          C.peekToxOptions ptr
-        res `shouldBe` Right options0
+        it "has a 'def' that is equivalent to the C default options" $ do
+            res <- C.withToxOptions C.peekToxOptions
+            res `shouldBe` Right C.defaultOptions
 
-    it "has a 'def' that is equivalent to the C default options" $ do
-      res <- C.withToxOptions C.peekToxOptions
-      res `shouldBe` Right def
+    describe "nospam" $ do
+        it "can be retrieved after being set" $ do
+            property $ \nospam ->
+                must $ C.withTox C.defaultOptions $ \tox -> do
+                    C.toxSelfSetNospam tox nospam
+                    nospam' <- C.toxSelfGetNospam tox
+                    nospam' `shouldBe` nospam
 
-  describe "nospam" $
-    it "can be retrieved after being set" $
-      property $ \nospam ->
-        must $ C.withDefaultTox $ \tox -> do
-          C.tox_self_set_nospam tox nospam
-          nospam' <- C.tox_self_get_nospam tox
-          nospam' `shouldBe` nospam
+    describe "public key" $ do
+        it "is a prefix of the address" $ do
+            must $ C.withTox C.defaultOptions $ \tox -> do
+                pk <- C.toxSelfGetPublicKey tox
+                addr <- C.toxSelfGetAddress tox
+                BS.unpack addr `shouldStartWith` BS.unpack pk
 
-  describe "public key" $ do
-    it "is a prefix of the address" $
-      must $ C.withDefaultTox $ \tox -> do
-        pk <- C.toxSelfGetPublicKey tox
-        addr <- C.toxSelfGetAddress tox
-        BS.unpack addr `shouldStartWith` BS.unpack pk
+        it "is not equal to the secret key" $ do
+            must $ C.withTox C.defaultOptions $ \tox -> do
+                pk <- C.toxSelfGetPublicKey tox
+                sk <- C.toxSelfGetSecretKey tox
+                pk `shouldNotBe` sk
 
-    it "is not equal to the secret key" $
-      must $ C.withDefaultTox $ \tox -> do
-        pk <- C.toxSelfGetPublicKey tox
-        sk <- C.toxSelfGetSecretKey tox
-        pk `shouldNotBe` sk
+    describe "error code enum" $ do
+        it "is correctly translated to Haskell" $ do
+            must $ C.withTox C.defaultOptions $ \tox -> do
+                err <- C.toxFriendSendMessage tox 0 C.MessageTypeNormal $ BS.pack [1, 2, 3]
+                err `shouldBe` Left C.ErrFriendSendMessageFriendNotFound

--- a/tools/groupbot.hs
+++ b/tools/groupbot.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase                 #-}
-{-# LANGUAGE StrictData                 #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE StrictData #-}
 module Main (main) where
 
 import           Control.Concurrent     (threadDelay)
@@ -13,7 +12,6 @@ import           Data.String            (fromString)
 import qualified Data.Text.Encoding     as Text
 import qualified Data.Text.IO           as Text
 import           Data.Word              (Word32)
-import           Foreign.Storable       (Storable (..))
 import           System.Directory       (doesFileExist)
 import           System.Exit            (exitSuccess)
 
@@ -32,8 +30,8 @@ Right masterKey =
 isMasterKey :: BS.ByteString -> Bool
 isMasterKey = (masterKey ==)
 
-botName :: String
-botName = "groupbot"
+botName :: BS.ByteString
+botName = fromString "groupbot"
 
 bootstrapHost :: String
 bootstrapHost = "tox.initramfs.io"
@@ -66,9 +64,9 @@ must = (getRight =<<)
 
 
 newtype UserData = UserData { groupNumber :: Word32 }
-    deriving (Eq, Storable, Read, Show)
+    deriving (Read, Show)
 
-handleEvent :: C.Tox a -> UserData -> Event -> IO UserData
+handleEvent :: C.Tox -> UserData -> Event -> IO UserData
 handleEvent tox ud@(UserData gn) = \case
     SelfConnectionStatus conn -> do
         putStrLn "SelfConnectionStatusCb"
@@ -120,7 +118,7 @@ handleEvent tox ud@(UserData gn) = \case
     _ -> return ud
 
 
-loop :: C.Tox a -> UserData -> IO ()
+loop :: C.Tox -> UserData -> IO ()
 loop tox ud = do
     interval <- C.toxIterationInterval tox
     threadDelay $ fromIntegral $ interval * 10000
@@ -134,17 +132,16 @@ main :: IO ()
 main = do
     exists <- doesFileExist savedataFilename
     loadedSavedata <- if exists then BS.readFile savedataFilename else return BS.empty
-    must $ C.withOptions (options loadedSavedata) $ \optPtr ->
-        must $ C.withTox optPtr $ \tox -> do
-            must $ C.toxBootstrap tox bootstrapHost 33445 bootstrapKey
+    must $ C.withTox (options loadedSavedata) $ \tox -> do
+        must $ C.toxBootstrap tox bootstrapHost 33445 bootstrapKey
 
-            adr <- C.toxSelfGetAddress tox
-            putStrLn $ (BS.unpack . Base16.encode) adr
-            _ <- C.toxSelfSetName tox botName
-            gn <- getRight =<< C.toxConferenceNew tox
-            catch (loop tox (UserData gn)) $ \case
-                e@UserInterrupt -> throwIO e
-                _ -> do
-                    savedSavedata <- C.toxGetSavedata tox
-                    BS.writeFile savedataFilename savedSavedata
-                    exitSuccess
+        adr <- C.toxSelfGetAddress tox
+        putStrLn $ (BS.unpack . Base16.encode) adr
+        _ <- C.toxSelfSetName tox botName
+        gn <- getRight =<< C.toxConferenceNew tox
+        catch (loop tox (UserData gn)) $ \case
+            e@UserInterrupt -> throwIO e
+            _ -> do
+                savedSavedata <- C.toxGetSavedata tox
+                BS.writeFile savedataFilename savedSavedata
+                exitSuccess

--- a/toxcore-c.cabal
+++ b/toxcore-c.cabal
@@ -39,7 +39,6 @@ library
       base < 5
     , QuickCheck
     , bytestring
-    , data-default-class
     , generic-arbitrary         < 0.2
     , msgpack-binary            >= 0.0.16
     , quickcheck-instances
@@ -79,7 +78,6 @@ test-suite testsuite
     , base16-bytestring
     , bytestring
     , cryptohash
-    , data-default-class
     , hspec
     , msgpack-binary
     , saltine


### PR DESCRIPTION
The events api no longer needs this. Toxes are no longer bound to any
userdata type. Applications can choose to pass around events and process
them on any userdata they want.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-toxcore-c/61)
<!-- Reviewable:end -->
