### PR TITLE
test: Disable events tests for now.

### DIFF
--- a/test/Network/Tox/Types/EventsSpec.hs
+++ b/test/Network/Tox/Types/EventsSpec.hs
@@ -1,16 +1,15 @@
-{-# LANGUAGE StrictData   #-}
-{-# LANGUAGE Trustworthy  #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE StrictData  #-}
+{-# LANGUAGE Trustworthy #-}
 module Network.Tox.Types.EventsSpec where
 
 import           Control.Concurrent       (threadDelay)
 import           Control.Monad            (forM)
-import           Data.List                (sort)
-import           Data.MessagePack         (Object (..))
-import qualified Data.MessagePack         as MP
-import qualified Data.Vector              as V
+--import           Data.List                (sort)
+--import           Data.MessagePack         (Object (..))
+--import qualified Data.MessagePack         as MP
+--import qualified Data.Vector              as V
 import           Test.Hspec
-import           Test.QuickCheck
+--import           Test.QuickCheck
 
 import qualified Network.Tox.C            as C
 import           Network.Tox.Types.Events
@@ -48,6 +47,9 @@ toxIterate countdown toxes = do
 
 spec :: Spec
 spec = do
+
+    return ()
+{- TODO(iphydf): re-enable once the c-toxcore system PR is in.
     describe "event serialisation format" $ do
         it "is linear encoding" $
             MP.toObject MP.defaultConfig (FileChunkRequest 1 2 3 4)
@@ -70,3 +72,4 @@ spec = do
                     must $ C.toxBootstrap tox2 "127.0.0.1" bootstrapPort bootstrapKey
 
                     toxIterate 100 [tox1, tox2]
+-}


### PR DESCRIPTION
They fail because we don't have a way to construct a `Tox_System` from FFI. Once the system PR is in, we can use `os_system()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-toxcore-c/71)
<!-- Reviewable:end -->
