### PR TITLE
chore: Disable targets for cross-compilation.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -23,6 +23,7 @@ haskell_library(
         ":api_tox_tox",
     ],
     src_strip_prefix = "src",
+    tags = ["no-cross"],
     version = "0.2.12",
     visibility = ["//visibility:public"],
     deps = [

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_haskell//haskell:defs.bzl", "haskell_binary")
 haskell_binary(
     name = "groupbot",
     srcs = ["groupbot.hs"],
+    tags = ["no-cross"],
     visibility = ["//tools/haskell:__pkg__"],
     deps = [
         "//hs-toxcore-c",


### PR DESCRIPTION
This way we can do bazel build //... when cross-compiling.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-toxcore-c/75)
<!-- Reviewable:end -->
