### PR TITLE
chore: Add genrule that uses Haskell to no-cross.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,6 +10,7 @@ project()
     outs = ["src/FFI/%s.hs" % "/".join([mod.capitalize() for mod in src[:-2].split("/")])],
     cmd = "$(location //hs-apigen/tools:apigen) -hs $< > $@",
     exec_tools = ["//hs-apigen/tools:apigen"],
+    tags = ["no-cross"],
 ) for src in [
     "tox/tox.h",
 ]]


### PR DESCRIPTION
It'll break arm64 builds otherwise.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-toxcore-c/76)
<!-- Reviewable:end -->
