### PR TITLE
chore: Disable apigen in hs-toxcore-c for now.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,24 +4,24 @@ load("//tools/project:build_defs.bzl", "project")
 
 project(license = "gpl3-https")
 
-[genrule(
-    name = "api_" + src[:-2].replace("/", "_"),
-    srcs = ["//c-toxcore:" + src],
-    outs = ["src/FFI/%s.hs" % "/".join([mod.capitalize() for mod in src[:-2].split("/")])],
-    cmd = "$(location //hs-apigen/tools:apigen) -hs $< > $@",
-    exec_tools = ["//hs-apigen/tools:apigen"],
-    tags = ["no-cross"],
-) for src in [
-    "tox/tox.h",
-]]
+#[genrule(
+#    name = "api_" + src[:-2].replace("/", "_"),
+#     srcs = ["//c-toxcore:" + src],
+#     outs = ["src/FFI/%s.hs" % "/".join([mod.capitalize() for mod in src[:-2].split("/")])],
+#     cmd = "$(location //hs-apigen/tools:apigen) -hs $< > $@",
+#     exec_tools = ["//hs-apigen/tools:apigen"],
+#     tags = ["no-cross"],
+# ) for src in [
+#     "tox/tox.h",
+# ]]
 
 haskell_library(
     name = "hs-toxcore-c",
     srcs = glob(
         ["src/**/*.*hs"],
-        exclude = ["src/FFI/**"],
+        #exclude = ["src/FFI/**"],
     ) + [
-        ":api_tox_tox",
+        #":api_tox_tox",
     ],
     src_strip_prefix = "src",
     tags = ["no-cross"],


### PR DESCRIPTION
The current haskell backend is broken. It'll be rewritten using the new apigen high level parser.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-toxcore-c/79)
<!-- Reviewable:end -->
